### PR TITLE
[bugfix]backendコンテナの権限の修正

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3'
 services:
   backend:
     platform: linux/x86_64
+    user: "${UID}:${GID}"
     build:
       dockerfile: ./docker/backend/Dockerfile
       context: .


### PR DESCRIPTION
ワイのPC(ubuntu 22.04)だとdocker-composeに`user: "${UID}:${GID}"`を入れないと動かないので一応PR投げます