### PR TITLE
[bugfix] test_schetify スキーマへの権限がなくてdb:migrate:reset でコケる問題の修正

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
       - 3306:3306
     volumes:
       - ./docker/mysql/conf.d:/etc/mysql/conf.d
+      - ./docker/mysql/initdb.d:/docker-entrypoint-initdb.d
       - mysql:/var/lib/mysql
       - ./log/mysql:/var/log/mysql
 

--- a/docker/mysql/initdb.d/test_schetify.sql
+++ b/docker/mysql/initdb.d/test_schetify.sql
@@ -1,0 +1,2 @@
+CREATE SCHEMA `test_schetify`;
+GRANT ALL PRIVILEGES ON `test_schetify`.* TO `user`@`%` WITH GRANT OPTION;


### PR DESCRIPTION
test用のデータベーススキーマ「test_schetify」に権限つけてないと，`rails db:migrate:reset` でコケるので追加．